### PR TITLE
fix code sample

### DIFF
--- a/ES2015.MD
+++ b/ES2015.MD
@@ -596,7 +596,6 @@ Calls in tail-position are guaranteed to not grow the stack unboundedly.  Makes 
 
 ```JavaScript
 function factorial(n, acc = 1) {
-    'use strict';
     if (n <= 1) return acc;
     return factorial(n - 1, n * acc);
 }


### PR DESCRIPTION
If the code that would otherwise give following error (in Firefox):
```
SyntaxError: "use strict" not allowed in function with default parameter
```