### PR TITLE
add an example

### DIFF
--- a/ES2017.MD
+++ b/ES2017.MD
@@ -190,3 +190,10 @@ const obj = {
   in: 'JavaScript..', 
 }
 ```
+
+> trailing commas in arguments
+```javascript
+const func = (a,b,c,) => {
+  // no error occurs
+};
+```


### PR DESCRIPTION
add "trailing commas in arguments" example.