### PR TITLE
fix: typo

### DIFF
--- a/ES2021.MD
+++ b/ES2021.MD
@@ -190,7 +190,7 @@ For the sake of simplicity, we passed a to-be-rejected promise to `Promise.any()
 
 ES2021 introduced the [numeric separator](https://github.com/tc39/proposal-numeric-separator) to improve the readability of numeric literals by creating a visual separation between groups of digits. As a result, we can use the underscore (`_`) character to separate groups of digits, just like we use commas to separate numbers in writing.
 
-This new feature of the language helps us circunvate the difficulty the human eye faces to quickly parse large numeric literals (especially when they involve long repetition of digits), so now it could be easier for developers to get the correct value or order of magnitude of long and/or confusing numeric literals in their code.
+This new feature of the language helps us circumvent the difficulty the human eye faces to quickly parse large numeric literals (especially when they involve long repetition of digits), so now it could be easier for developers to get the correct value or order of magnitude of long and/or confusing numeric literals in their code.
 
 Let's take a look at some examples:
 


### PR DESCRIPTION
I can't find the word "circunvate". Not sure whether it's typo or not.